### PR TITLE
Add support for the ZodLiteral type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-zod",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Gemini AI Schema to Zod Adapter",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -67,6 +67,18 @@ describe('toGeminiSchema', () => {
         required: ['user', 'scores'],
       });
     });
+  
+    test('converts ZodLiteral to Gemini schema', () => {
+      const zodSchema = z.literal('hello');
+  
+      const geminiSchema = toGeminiSchema(zodSchema);
+  
+      expect(geminiSchema).toEqual({
+        type: SchemaType.STRING,
+        enum: ['hello'],
+        nullable: false,
+      });
+    });
 });
 
 describe('toZodSchema', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,12 @@ export function toGeminiSchema(zodSchema: any): any {
       case 'ZodOptional':
         const innerSchema = toGeminiSchema(zodSchema._def.innerType);
         return { ...innerSchema, nullable: true };
+      case 'ZodLiteral':
+        return {
+            type: SchemaType.STRING,
+            enum: [zodSchema._def.value],
+            nullable: zodSchema.isOptional(),
+        };
       default:
         return {
           type: SchemaType.OBJECT,


### PR DESCRIPTION
**Implementation Details**
The implementation adds a new case in the toGeminiSchema function to handle ZodLiteral types. 

When a literal type is encountered, it's converted to a Gemini schema with:
- type: SchemaType.STRING
- enum field containing a single-item list with the literal value, to constrain the possible values the string can take.
- nullable status based on optional state from zod

**Testing**
- Added unit test to verify ZodLiteral conversion
- All existing tests pass
- Did some manual testing with literal values

Let me know if you would like me to expand on any part of this PR description!