### PR TITLE
Support .nullable()

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -4,143 +4,143 @@ import { toGeminiSchema, toZodSchema } from '../index';
 import { z } from 'zod';
 
 describe('toGeminiSchema', () => {
-  test('converts ZodObject to Gemini schema', () => {
-    const zodSchema = z.object({
-      name: z.string(),
-      age: z.number(),
-      isStudent: z.boolean(),
-      optional: z.string().optional(),
-      nullable: z.string().nullable(),
-    });
-
-    const geminiSchema = toGeminiSchema(zodSchema);
-
-    expect(geminiSchema).toEqual({
-      type: SchemaType.OBJECT,
-      properties: {
-        name: { type: SchemaType.STRING, nullable: false },
-        age: { type: SchemaType.NUMBER, nullable: false },
-        isStudent: { type: SchemaType.BOOLEAN, nullable: false },
-        optional: { type: SchemaType.STRING, nullable: true },
-        nullable: { type: SchemaType.STRING, nullable: true },
-      },
-      required: ['name', 'age', 'isStudent', 'nullable'],
-    });
-  });
-
-  test('converts ZodArray to Gemini schema', () => {
-    const zodSchema = z.array(z.string());
-
-    const geminiSchema = toGeminiSchema(zodSchema);
-
-    expect(geminiSchema).toEqual({
-      type: SchemaType.ARRAY,
-      items: { type: SchemaType.STRING, nullable: false },
-    });
-  });
-
-  test('converts nested ZodObject to Gemini schema', () => {
-    const zodSchema = z.object({
-      user: z.object({
+    test('converts ZodObject to Gemini schema', () => {
+      const zodSchema = z.object({
         name: z.string(),
         age: z.number(),
-      }),
-      scores: z.array(z.number()),
+        isStudent: z.boolean(),
+        optional: z.string().optional(),
+        nullable: z.string().nullable(),
+      });
+
+      const geminiSchema = toGeminiSchema(zodSchema);
+
+      expect(geminiSchema).toEqual({
+        type: SchemaType.OBJECT,
+        properties: {
+          name: { type: SchemaType.STRING, nullable: false },
+          age: { type: SchemaType.NUMBER, nullable: false },
+          isStudent: { type: SchemaType.BOOLEAN, nullable: false },
+          optional: { type: SchemaType.STRING, nullable: true },
+          nullable: { type: SchemaType.STRING, nullable: true },
+        },
+        required: ['name', 'age', 'isStudent', 'nullable'],
+      });
     });
 
-    const geminiSchema = toGeminiSchema(zodSchema);
+    test('converts ZodArray to Gemini schema', () => {
+      const zodSchema = z.array(z.string());
 
-    expect(geminiSchema).toEqual({
-      type: SchemaType.OBJECT,
-      properties: {
-        user: {
-          type: SchemaType.OBJECT,
-          properties: {
-            name: { type: SchemaType.STRING, nullable: false },
-            age: { type: SchemaType.NUMBER, nullable: false },
+      const geminiSchema = toGeminiSchema(zodSchema);
+
+      expect(geminiSchema).toEqual({
+        type: SchemaType.ARRAY,
+        items: { type: SchemaType.STRING, nullable: false },
+      });
+    });
+
+    test('converts nested ZodObject to Gemini schema', () => {
+      const zodSchema = z.object({
+        user: z.object({
+          name: z.string(),
+          age: z.number(),
+        }),
+        scores: z.array(z.number()),
+      });
+
+      const geminiSchema = toGeminiSchema(zodSchema);
+
+      expect(geminiSchema).toEqual({
+        type: SchemaType.OBJECT,
+        properties: {
+          user: {
+            type: SchemaType.OBJECT,
+            properties: {
+              name: { type: SchemaType.STRING, nullable: false },
+              age: { type: SchemaType.NUMBER, nullable: false },
+            },
+            required: ['name', 'age'],
           },
-          required: ['name', 'age'],
+          scores: {
+            type: SchemaType.ARRAY,
+            items: { type: SchemaType.NUMBER, nullable: false },
+          },
         },
-        scores: {
-          type: SchemaType.ARRAY,
-          items: { type: SchemaType.NUMBER, nullable: false },
-        },
-      },
-      required: ['user', 'scores'],
+        required: ['user', 'scores'],
+      });
     });
-  });
 });
 
 describe('toZodSchema', () => {
-  test('converts Gemini object schema to ZodObject', () => {
-    const geminiSchema = {
-      type: SchemaType.OBJECT,
-      properties: {
-        name: { type: SchemaType.STRING },
-        age: { type: SchemaType.NUMBER },
-        isStudent: { type: SchemaType.BOOLEAN },
-        optional: { type: SchemaType.STRING, nullable: true },
-      },
-      required: ['name', 'age', 'isStudent'],
-    };
+    test('converts Gemini object schema to ZodObject', () => {
+      const geminiSchema = {
+        type: SchemaType.OBJECT,
+        properties: {
+          name: { type: SchemaType.STRING },
+          age: { type: SchemaType.NUMBER },
+          isStudent: { type: SchemaType.BOOLEAN },
+          optional: { type: SchemaType.STRING, nullable: true },
+        },
+        required: ['name', 'age', 'isStudent'],
+      };
 
-    const zodSchema = toZodSchema(geminiSchema);
+      const zodSchema = toZodSchema(geminiSchema);
 
-    expect(zodSchema).toBeInstanceOf(z.ZodObject);
-    const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
-    expect(castedZodSchema.shape.name).toBeInstanceOf(z.ZodString);
-    expect(castedZodSchema.shape.age).toBeInstanceOf(z.ZodNumber);
-    expect(castedZodSchema.shape.isStudent).toBeInstanceOf(z.ZodBoolean);
-    expect(castedZodSchema.shape.optional).toBeInstanceOf(z.ZodOptional);
-  });
+      expect(zodSchema).toBeInstanceOf(z.ZodObject);
+      const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
+      expect(castedZodSchema.shape.name).toBeInstanceOf(z.ZodString);
+      expect(castedZodSchema.shape.age).toBeInstanceOf(z.ZodNumber);
+      expect(castedZodSchema.shape.isStudent).toBeInstanceOf(z.ZodBoolean);
+      expect(castedZodSchema.shape.optional).toBeInstanceOf(z.ZodOptional);
+    });
 
-  test('converts Gemini array schema to ZodArray', () => {
-    const geminiSchema = {
-      type: SchemaType.ARRAY,
-      items: { type: SchemaType.STRING },
-    };
+    test('converts Gemini array schema to ZodArray', () => {
+      const geminiSchema = {
+        type: SchemaType.ARRAY,
+        items: { type: SchemaType.STRING },
+      };
 
-    const zodSchema = toZodSchema(geminiSchema);
+      const zodSchema = toZodSchema(geminiSchema);
 
-    expect(zodSchema).toBeInstanceOf(z.ZodArray);
-    const castedZodSchema = zodSchema as z.ZodArray<any>;
-    expect(castedZodSchema.element).toBeInstanceOf(z.ZodString);
-  });
+      expect(zodSchema).toBeInstanceOf(z.ZodArray);
+      const castedZodSchema = zodSchema as z.ZodArray<any>;
+      expect(castedZodSchema.element).toBeInstanceOf(z.ZodString);
+    });
 
-  test('converts nested Gemini schema to nested Zod schema', () => {
-    const geminiSchema = {
-      type: SchemaType.OBJECT,
-      properties: {
-        user: {
-          type: SchemaType.OBJECT,
-          properties: {
-            name: { type: SchemaType.STRING },
-            age: { type: SchemaType.NUMBER },
+    test('converts nested Gemini schema to nested Zod schema', () => {
+      const geminiSchema = {
+        type: SchemaType.OBJECT,
+        properties: {
+          user: {
+            type: SchemaType.OBJECT,
+            properties: {
+              name: { type: SchemaType.STRING },
+              age: { type: SchemaType.NUMBER },
+            },
+            required: ['name', 'age'],
           },
-          required: ['name', 'age'],
+          scores: {
+            type: SchemaType.ARRAY,
+            items: { type: SchemaType.NUMBER },
+          },
         },
-        scores: {
-          type: SchemaType.ARRAY,
-          items: { type: SchemaType.NUMBER },
-        },
-      },
-      required: ['user', 'scores'],
-    };
+        required: ['user', 'scores'],
+      };
 
-    const zodSchema = toZodSchema(geminiSchema);
+      const zodSchema = toZodSchema(geminiSchema);
 
-    expect(zodSchema).toBeInstanceOf(z.ZodObject);
-    const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
-    expect(castedZodSchema.shape.user).toBeInstanceOf(z.ZodObject);
-    expect(castedZodSchema.shape.scores).toBeInstanceOf(z.ZodArray);
-    expect(
-      (castedZodSchema.shape.user as z.ZodObject<any>).shape.name,
-    ).toBeInstanceOf(z.ZodString);
-    expect(
-      (castedZodSchema.shape.user as z.ZodObject<any>).shape.age,
-    ).toBeInstanceOf(z.ZodNumber);
-    expect(
-      (castedZodSchema.shape.scores as z.ZodArray<any>).element,
-    ).toBeInstanceOf(z.ZodNumber);
-  });
+      expect(zodSchema).toBeInstanceOf(z.ZodObject);
+      const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
+      expect(castedZodSchema.shape.user).toBeInstanceOf(z.ZodObject);
+      expect(castedZodSchema.shape.scores).toBeInstanceOf(z.ZodArray);
+      expect(
+        (castedZodSchema.shape.user as z.ZodObject<any>).shape.name,
+      ).toBeInstanceOf(z.ZodString);
+      expect(
+        (castedZodSchema.shape.user as z.ZodObject<any>).shape.age,
+      ).toBeInstanceOf(z.ZodNumber);
+      expect(
+        (castedZodSchema.shape.scores as z.ZodArray<any>).element,
+      ).toBeInstanceOf(z.ZodNumber);
+    });
 });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,74 +1,83 @@
 // src/__tests__/main.test.ts
-import { SchemaType } from '../util'
+import { SchemaType } from '../util';
 import { toGeminiSchema, toZodSchema } from '../index';
 import { z } from 'zod';
 
 describe('toGeminiSchema', () => {
-    test('converts ZodObject to Gemini schema', () => {
-      const zodSchema = z.object({
+  test('converts ZodObject to Gemini schema', () => {
+    const zodSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+      isStudent: z.boolean(),
+      optional: z.string().optional(),
+      nullable: z.string().nullable().describe('This is a nullable string'),
+    });
+
+    const geminiSchema = toGeminiSchema(zodSchema);
+
+    expect(geminiSchema).toEqual({
+      type: SchemaType.OBJECT,
+      properties: {
+        name: { type: SchemaType.STRING, nullable: false },
+        age: { type: SchemaType.NUMBER, nullable: false },
+        isStudent: { type: SchemaType.BOOLEAN, nullable: false },
+        optional: { type: SchemaType.STRING, nullable: true },
+        nullable: {
+          type: SchemaType.STRING,
+          nullable: true,
+          description: 'This is a nullable string',
+        },
+      },
+      required: ['name', 'age', 'isStudent', 'nullable'],
+      nullable: false,
+    });
+  });
+
+  test('converts ZodArray to Gemini schema', () => {
+    const zodSchema = z.array(z.string());
+
+    const geminiSchema = toGeminiSchema(zodSchema);
+
+    expect(geminiSchema).toEqual({
+      type: SchemaType.ARRAY,
+      items: { type: SchemaType.STRING, nullable: false },
+      nullable: false,
+    });
+  });
+
+  test('converts nested ZodObject to Gemini schema', () => {
+    const zodSchema = z.object({
+      user: z.object({
         name: z.string(),
         age: z.number(),
-        isStudent: z.boolean(),
-        optional: z.string().optional(),
-        nullable: z.string().nullable(),
-      });
-  
-      const geminiSchema = toGeminiSchema(zodSchema);
-  
-      expect(geminiSchema).toEqual({
-        type: SchemaType.OBJECT,
-        properties: {
-          name: { type: SchemaType.STRING, nullable: false },
-          age: { type: SchemaType.NUMBER, nullable: false },
-          isStudent: { type: SchemaType.BOOLEAN, nullable: false },
-          optional: { type: SchemaType.STRING, nullable: true },
-          nullable: { type: SchemaType.STRING, nullable: true },
-        },
-        required: ['name', 'age', 'isStudent', 'nullable'],
-      });
+      }),
+      scores: z.array(z.number()),
     });
-  
-    test('converts ZodArray to Gemini schema', () => {
-      const zodSchema = z.array(z.string());
-  
-      const geminiSchema = toGeminiSchema(zodSchema);
-  
-      expect(geminiSchema).toEqual({
-        type: SchemaType.ARRAY,
-        items: { type: SchemaType.STRING, nullable: false },
-      });
-    });
-  
-    test('converts nested ZodObject to Gemini schema', () => {
-      const zodSchema = z.object({
-        user: z.object({
-          name: z.string(),
-          age: z.number(),
-        }),
-        scores: z.array(z.number()),
-      });
-  
-      const geminiSchema = toGeminiSchema(zodSchema);
-  
-      expect(geminiSchema).toEqual({
-        type: SchemaType.OBJECT,
-        properties: {
-          user: {
-            type: SchemaType.OBJECT,
-            properties: {
-              name: { type: SchemaType.STRING, nullable: false },
-              age: { type: SchemaType.NUMBER, nullable: false },
-            },
-            required: ['name', 'age'],
+
+    const geminiSchema = toGeminiSchema(zodSchema);
+
+    expect(geminiSchema).toEqual({
+      type: SchemaType.OBJECT,
+      properties: {
+        user: {
+          type: SchemaType.OBJECT,
+          properties: {
+            name: { type: SchemaType.STRING, nullable: false },
+            age: { type: SchemaType.NUMBER, nullable: false },
           },
-          scores: {
-            type: SchemaType.ARRAY,
-            items: { type: SchemaType.NUMBER, nullable: false },
-          },
+          required: ['name', 'age'],
+          nullable: false,
         },
-        required: ['user', 'scores'],
-      });
+        scores: {
+          type: SchemaType.ARRAY,
+          items: { type: SchemaType.NUMBER, nullable: false },
+          nullable: false,
+        },
+      },
+      required: ['user', 'scores'],
+      nullable: false,
     });
+  });
 });
 
 describe('toZodSchema', () => {
@@ -133,8 +142,14 @@ describe('toZodSchema', () => {
     const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
     expect(castedZodSchema.shape.user).toBeInstanceOf(z.ZodObject);
     expect(castedZodSchema.shape.scores).toBeInstanceOf(z.ZodArray);
-    expect((castedZodSchema.shape.user as z.ZodObject<any>).shape.name).toBeInstanceOf(z.ZodString);
-    expect((castedZodSchema.shape.user as z.ZodObject<any>).shape.age).toBeInstanceOf(z.ZodNumber);
-    expect((castedZodSchema.shape.scores as z.ZodArray<any>).element).toBeInstanceOf(z.ZodNumber);
+    expect(
+      (castedZodSchema.shape.user as z.ZodObject<any>).shape.name,
+    ).toBeInstanceOf(z.ZodString);
+    expect(
+      (castedZodSchema.shape.user as z.ZodObject<any>).shape.age,
+    ).toBeInstanceOf(z.ZodNumber);
+    expect(
+      (castedZodSchema.shape.scores as z.ZodArray<any>).element,
+    ).toBeInstanceOf(z.ZodNumber);
   });
 });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,72 +1,74 @@
 // src/__tests__/main.test.ts
-import { SchemaType } from '../util'
+import { SchemaType } from '../util';
 import { toGeminiSchema, toZodSchema } from '../index';
 import { z } from 'zod';
 
 describe('toGeminiSchema', () => {
-    test('converts ZodObject to Gemini schema', () => {
-      const zodSchema = z.object({
+  test('converts ZodObject to Gemini schema', () => {
+    const zodSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+      isStudent: z.boolean(),
+      optional: z.string().optional(),
+      nullable: z.string().nullable(),
+    });
+
+    const geminiSchema = toGeminiSchema(zodSchema);
+
+    expect(geminiSchema).toEqual({
+      type: SchemaType.OBJECT,
+      properties: {
+        name: { type: SchemaType.STRING, nullable: false },
+        age: { type: SchemaType.NUMBER, nullable: false },
+        isStudent: { type: SchemaType.BOOLEAN, nullable: false },
+        optional: { type: SchemaType.STRING, nullable: true },
+        nullable: { type: SchemaType.STRING, nullable: true },
+      },
+      required: ['name', 'age', 'isStudent', 'nullable'],
+    });
+  });
+
+  test('converts ZodArray to Gemini schema', () => {
+    const zodSchema = z.array(z.string());
+
+    const geminiSchema = toGeminiSchema(zodSchema);
+
+    expect(geminiSchema).toEqual({
+      type: SchemaType.ARRAY,
+      items: { type: SchemaType.STRING, nullable: false },
+    });
+  });
+
+  test('converts nested ZodObject to Gemini schema', () => {
+    const zodSchema = z.object({
+      user: z.object({
         name: z.string(),
         age: z.number(),
-        isStudent: z.boolean(),
-        optional: z.string().optional(),
-      });
-  
-      const geminiSchema = toGeminiSchema(zodSchema);
-  
-      expect(geminiSchema).toEqual({
-        type: SchemaType.OBJECT,
-        properties: {
-          name: { type: SchemaType.STRING, nullable: false },
-          age: { type: SchemaType.NUMBER, nullable: false },
-          isStudent: { type: SchemaType.BOOLEAN, nullable: false },
-          optional: { type: SchemaType.STRING, nullable: true },
-        },
-        required: ['name', 'age', 'isStudent'],
-      });
+      }),
+      scores: z.array(z.number()),
     });
-  
-    test('converts ZodArray to Gemini schema', () => {
-      const zodSchema = z.array(z.string());
-  
-      const geminiSchema = toGeminiSchema(zodSchema);
-  
-      expect(geminiSchema).toEqual({
-        type: SchemaType.ARRAY,
-        items: { type: SchemaType.STRING, nullable: false },
-      });
-    });
-  
-    test('converts nested ZodObject to Gemini schema', () => {
-      const zodSchema = z.object({
-        user: z.object({
-          name: z.string(),
-          age: z.number(),
-        }),
-        scores: z.array(z.number()),
-      });
-  
-      const geminiSchema = toGeminiSchema(zodSchema);
-  
-      expect(geminiSchema).toEqual({
-        type: SchemaType.OBJECT,
-        properties: {
-          user: {
-            type: SchemaType.OBJECT,
-            properties: {
-              name: { type: SchemaType.STRING, nullable: false },
-              age: { type: SchemaType.NUMBER, nullable: false },
-            },
-            required: ['name', 'age'],
+
+    const geminiSchema = toGeminiSchema(zodSchema);
+
+    expect(geminiSchema).toEqual({
+      type: SchemaType.OBJECT,
+      properties: {
+        user: {
+          type: SchemaType.OBJECT,
+          properties: {
+            name: { type: SchemaType.STRING, nullable: false },
+            age: { type: SchemaType.NUMBER, nullable: false },
           },
-          scores: {
-            type: SchemaType.ARRAY,
-            items: { type: SchemaType.NUMBER, nullable: false },
-          },
+          required: ['name', 'age'],
         },
-        required: ['user', 'scores'],
-      });
+        scores: {
+          type: SchemaType.ARRAY,
+          items: { type: SchemaType.NUMBER, nullable: false },
+        },
+      },
+      required: ['user', 'scores'],
     });
+  });
 });
 
 describe('toZodSchema', () => {
@@ -131,8 +133,14 @@ describe('toZodSchema', () => {
     const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
     expect(castedZodSchema.shape.user).toBeInstanceOf(z.ZodObject);
     expect(castedZodSchema.shape.scores).toBeInstanceOf(z.ZodArray);
-    expect((castedZodSchema.shape.user as z.ZodObject<any>).shape.name).toBeInstanceOf(z.ZodString);
-    expect((castedZodSchema.shape.user as z.ZodObject<any>).shape.age).toBeInstanceOf(z.ZodNumber);
-    expect((castedZodSchema.shape.scores as z.ZodArray<any>).element).toBeInstanceOf(z.ZodNumber);
+    expect(
+      (castedZodSchema.shape.user as z.ZodObject<any>).shape.name,
+    ).toBeInstanceOf(z.ZodString);
+    expect(
+      (castedZodSchema.shape.user as z.ZodObject<any>).shape.age,
+    ).toBeInstanceOf(z.ZodNumber);
+    expect(
+      (castedZodSchema.shape.scores as z.ZodArray<any>).element,
+    ).toBeInstanceOf(z.ZodNumber);
   });
 });

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,5 +1,5 @@
 // src/__tests__/main.test.ts
-import { SchemaType } from '../util';
+import { SchemaType } from '../util'
 import { toGeminiSchema, toZodSchema } from '../index';
 import { z } from 'zod';
 
@@ -12,9 +12,9 @@ describe('toGeminiSchema', () => {
         optional: z.string().optional(),
         nullable: z.string().nullable(),
       });
-
+  
       const geminiSchema = toGeminiSchema(zodSchema);
-
+  
       expect(geminiSchema).toEqual({
         type: SchemaType.OBJECT,
         properties: {
@@ -27,18 +27,18 @@ describe('toGeminiSchema', () => {
         required: ['name', 'age', 'isStudent', 'nullable'],
       });
     });
-
+  
     test('converts ZodArray to Gemini schema', () => {
       const zodSchema = z.array(z.string());
-
+  
       const geminiSchema = toGeminiSchema(zodSchema);
-
+  
       expect(geminiSchema).toEqual({
         type: SchemaType.ARRAY,
         items: { type: SchemaType.STRING, nullable: false },
       });
     });
-
+  
     test('converts nested ZodObject to Gemini schema', () => {
       const zodSchema = z.object({
         user: z.object({
@@ -47,9 +47,9 @@ describe('toGeminiSchema', () => {
         }),
         scores: z.array(z.number()),
       });
-
+  
       const geminiSchema = toGeminiSchema(zodSchema);
-
+  
       expect(geminiSchema).toEqual({
         type: SchemaType.OBJECT,
         properties: {
@@ -72,75 +72,69 @@ describe('toGeminiSchema', () => {
 });
 
 describe('toZodSchema', () => {
-    test('converts Gemini object schema to ZodObject', () => {
-      const geminiSchema = {
-        type: SchemaType.OBJECT,
-        properties: {
-          name: { type: SchemaType.STRING },
-          age: { type: SchemaType.NUMBER },
-          isStudent: { type: SchemaType.BOOLEAN },
-          optional: { type: SchemaType.STRING, nullable: true },
-        },
-        required: ['name', 'age', 'isStudent'],
-      };
+  test('converts Gemini object schema to ZodObject', () => {
+    const geminiSchema = {
+      type: SchemaType.OBJECT,
+      properties: {
+        name: { type: SchemaType.STRING },
+        age: { type: SchemaType.NUMBER },
+        isStudent: { type: SchemaType.BOOLEAN },
+        optional: { type: SchemaType.STRING, nullable: true },
+      },
+      required: ['name', 'age', 'isStudent'],
+    };
 
-      const zodSchema = toZodSchema(geminiSchema);
+    const zodSchema = toZodSchema(geminiSchema);
 
-      expect(zodSchema).toBeInstanceOf(z.ZodObject);
-      const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
-      expect(castedZodSchema.shape.name).toBeInstanceOf(z.ZodString);
-      expect(castedZodSchema.shape.age).toBeInstanceOf(z.ZodNumber);
-      expect(castedZodSchema.shape.isStudent).toBeInstanceOf(z.ZodBoolean);
-      expect(castedZodSchema.shape.optional).toBeInstanceOf(z.ZodOptional);
-    });
+    expect(zodSchema).toBeInstanceOf(z.ZodObject);
+    const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
+    expect(castedZodSchema.shape.name).toBeInstanceOf(z.ZodString);
+    expect(castedZodSchema.shape.age).toBeInstanceOf(z.ZodNumber);
+    expect(castedZodSchema.shape.isStudent).toBeInstanceOf(z.ZodBoolean);
+    expect(castedZodSchema.shape.optional).toBeInstanceOf(z.ZodOptional);
+  });
 
-    test('converts Gemini array schema to ZodArray', () => {
-      const geminiSchema = {
-        type: SchemaType.ARRAY,
-        items: { type: SchemaType.STRING },
-      };
+  test('converts Gemini array schema to ZodArray', () => {
+    const geminiSchema = {
+      type: SchemaType.ARRAY,
+      items: { type: SchemaType.STRING },
+    };
 
-      const zodSchema = toZodSchema(geminiSchema);
+    const zodSchema = toZodSchema(geminiSchema);
 
-      expect(zodSchema).toBeInstanceOf(z.ZodArray);
-      const castedZodSchema = zodSchema as z.ZodArray<any>;
-      expect(castedZodSchema.element).toBeInstanceOf(z.ZodString);
-    });
+    expect(zodSchema).toBeInstanceOf(z.ZodArray);
+    const castedZodSchema = zodSchema as z.ZodArray<any>;
+    expect(castedZodSchema.element).toBeInstanceOf(z.ZodString);
+  });
 
-    test('converts nested Gemini schema to nested Zod schema', () => {
-      const geminiSchema = {
-        type: SchemaType.OBJECT,
-        properties: {
-          user: {
-            type: SchemaType.OBJECT,
-            properties: {
-              name: { type: SchemaType.STRING },
-              age: { type: SchemaType.NUMBER },
-            },
-            required: ['name', 'age'],
+  test('converts nested Gemini schema to nested Zod schema', () => {
+    const geminiSchema = {
+      type: SchemaType.OBJECT,
+      properties: {
+        user: {
+          type: SchemaType.OBJECT,
+          properties: {
+            name: { type: SchemaType.STRING },
+            age: { type: SchemaType.NUMBER },
           },
-          scores: {
-            type: SchemaType.ARRAY,
-            items: { type: SchemaType.NUMBER },
-          },
+          required: ['name', 'age'],
         },
-        required: ['user', 'scores'],
-      };
+        scores: {
+          type: SchemaType.ARRAY,
+          items: { type: SchemaType.NUMBER },
+        },
+      },
+      required: ['user', 'scores'],
+    };
 
-      const zodSchema = toZodSchema(geminiSchema);
+    const zodSchema = toZodSchema(geminiSchema);
 
-      expect(zodSchema).toBeInstanceOf(z.ZodObject);
-      const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
-      expect(castedZodSchema.shape.user).toBeInstanceOf(z.ZodObject);
-      expect(castedZodSchema.shape.scores).toBeInstanceOf(z.ZodArray);
-      expect(
-        (castedZodSchema.shape.user as z.ZodObject<any>).shape.name,
-      ).toBeInstanceOf(z.ZodString);
-      expect(
-        (castedZodSchema.shape.user as z.ZodObject<any>).shape.age,
-      ).toBeInstanceOf(z.ZodNumber);
-      expect(
-        (castedZodSchema.shape.scores as z.ZodArray<any>).element,
-      ).toBeInstanceOf(z.ZodNumber);
-    });
+    expect(zodSchema).toBeInstanceOf(z.ZodObject);
+    const castedZodSchema = zodSchema as z.ZodObject<any, any, any>;
+    expect(castedZodSchema.shape.user).toBeInstanceOf(z.ZodObject);
+    expect(castedZodSchema.shape.scores).toBeInstanceOf(z.ZodArray);
+    expect((castedZodSchema.shape.user as z.ZodObject<any>).shape.name).toBeInstanceOf(z.ZodString);
+    expect((castedZodSchema.shape.user as z.ZodObject<any>).shape.age).toBeInstanceOf(z.ZodNumber);
+    expect((castedZodSchema.shape.scores as z.ZodArray<any>).element).toBeInstanceOf(z.ZodNumber);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,94 +1,94 @@
 import { getZodType, SchemaType } from './util';
 
 export function toGeminiSchema(zodSchema: any): any {
-  const zodType = getZodType(zodSchema);
+    const zodType = getZodType(zodSchema);
 
-  switch (zodType) {
-    case 'ZodArray':
-      return {
-        type: SchemaType.ARRAY,
-        items: toGeminiSchema(zodSchema.element),
-      };
-    case 'ZodObject':
-      const properties: Record<string, any> = {};
-      const required: string[] = [];
+    switch (zodType) {
+      case 'ZodArray':
+        return {
+          type: SchemaType.ARRAY,
+          items: toGeminiSchema(zodSchema.element),
+        };
+      case 'ZodObject':
+        const properties: Record<string, any> = {};
+        const required: string[] = [];
 
-      Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
-        properties[key] = toGeminiSchema(value);
-        if (getZodType(value) !== 'ZodOptional') {
-          required.push(key);
-        }
-      });
+        Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
+          properties[key] = toGeminiSchema(value);
+          if (getZodType(value) !== 'ZodOptional') {
+            required.push(key);
+          }
+        });
 
-      return {
-        type: SchemaType.OBJECT,
-        properties,
-        required: required.length > 0 ? required : undefined,
-      };
-    case 'ZodString':
-      return {
-        type: SchemaType.STRING,
-        nullable: zodSchema.isOptional(),
-      };
-    case 'ZodNumber':
-      return {
-        type: SchemaType.NUMBER,
-        nullable: zodSchema.isOptional(),
-      };
-    case 'ZodBoolean':
-      return {
-        type: SchemaType.BOOLEAN,
-        nullable: zodSchema.isOptional(),
-      };
-    case 'ZodEnum':
-      return {
-        type: SchemaType.STRING,
-        enum: zodSchema._def.values,
-        nullable: zodSchema.isOptional(),
-      };
-    case 'ZodNullable':
-    case 'ZodOptional':
-      const innerSchema = toGeminiSchema(zodSchema._def.innerType);
-      return { ...innerSchema, nullable: true };
-    default:
-      return {
-        type: SchemaType.OBJECT,
-        nullable: true,
-      };
-  }
+        return {
+          type: SchemaType.OBJECT,
+          properties,
+          required: required.length > 0 ? required : undefined,
+        };
+      case 'ZodString':
+        return {
+          type: SchemaType.STRING,
+          nullable: zodSchema.isOptional(),
+        };
+      case 'ZodNumber':
+        return {
+          type: SchemaType.NUMBER,
+          nullable: zodSchema.isOptional(),
+        };
+      case 'ZodBoolean':
+        return {
+          type: SchemaType.BOOLEAN,
+          nullable: zodSchema.isOptional(),
+        };
+      case 'ZodEnum':
+        return {
+          type: SchemaType.STRING,
+          enum: zodSchema._def.values,
+          nullable: zodSchema.isOptional(),
+        };
+      case 'ZodNullable':
+      case 'ZodOptional':
+        const innerSchema = toGeminiSchema(zodSchema._def.innerType);
+        return { ...innerSchema, nullable: true };
+      default:
+        return {
+          type: SchemaType.OBJECT,
+          nullable: true,
+        };
+    }
 }
 
 export function toZodSchema(geminiSchema: any): any {
-  const z = require('zod'); // Dynamically import zod to avoid bundling it
+    const z = require('zod'); // Dynamically import zod to avoid bundling it
 
-  switch (geminiSchema.type) {
-    case SchemaType.ARRAY:
-      return z.array(toZodSchema(geminiSchema.items));
+    switch (geminiSchema.type) {
+      case SchemaType.ARRAY:
+        return z.array(toZodSchema(geminiSchema.items));
 
-    case SchemaType.OBJECT:
-      const shape: Record<string, any> = {};
-      Object.entries(geminiSchema.properties).forEach(
-        ([key, value]: [string, any]) => {
-          let fieldSchema = toZodSchema(value);
-          if (!geminiSchema.required || !geminiSchema.required.includes(key)) {
-            fieldSchema = fieldSchema.optional();
-          }
-          shape[key] = fieldSchema;
-        },
-      );
-      return z.object(shape);
+      case SchemaType.OBJECT:
+        const shape: Record<string, any> = {};
+        Object.entries(geminiSchema.properties).forEach(
+          ([key, value]: [string, any]) => {
+            let fieldSchema = toZodSchema(value);
+            if (!geminiSchema.required || !geminiSchema.required.includes(key)) {
+              fieldSchema = fieldSchema.optional();
+            }
+            shape[key] = fieldSchema;
+          },
+        );
+        return z.object(shape);
 
-    case SchemaType.STRING:
-      return geminiSchema.nullable ? z.string().nullable() : z.string();
+      case SchemaType.STRING:
+        return geminiSchema.nullable ? z.string().nullable() : z.string();
 
-    case SchemaType.NUMBER:
-    case SchemaType.INTEGER:
-      return geminiSchema.nullable ? z.number().nullable() : z.number();
+      case SchemaType.NUMBER:
+      case SchemaType.INTEGER:
+        return geminiSchema.nullable ? z.number().nullable() : z.number();
 
-    case SchemaType.BOOLEAN:
-      return geminiSchema.nullable ? z.boolean().nullable() : z.boolean();
+      case SchemaType.BOOLEAN:
+        return geminiSchema.nullable ? z.boolean().nullable() : z.boolean();
 
-    default:
-      return geminiSchema.nullable ? z.any().nullable() : z.any();
-  }
+      default:
+        return geminiSchema.nullable ? z.any().nullable() : z.any();
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,91 +1,94 @@
 import { getZodType, SchemaType } from './util';
 
 export function toGeminiSchema(zodSchema: any): any {
-    const zodType = getZodType(zodSchema);
-  
-    switch (zodType) {
-      case 'ZodArray':
-        return {
-          type: SchemaType.ARRAY,
-          items: toGeminiSchema(zodSchema.element),
-        };
-      case 'ZodObject':
-        const properties: Record<string, any> = {};
-        const required: string[] = [];
-  
-        Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
-          properties[key] = toGeminiSchema(value);
-          if (getZodType(value) !== 'ZodOptional') {
-            required.push(key);
-          }
-        });
-  
-        return {
-          type: SchemaType.OBJECT,
-          properties,
-          required: required.length > 0 ? required : undefined,
-        };
-      case 'ZodString':
-        return {
-          type: SchemaType.STRING,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodNumber':
-        return {
-          type: SchemaType.NUMBER,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodBoolean':
-        return {
-          type: SchemaType.BOOLEAN,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodEnum':
-        return {
-          type: SchemaType.STRING,
-          enum: zodSchema._def.values,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodOptional':
-        const innerSchema = toGeminiSchema(zodSchema._def.innerType);
-        return { ...innerSchema, nullable: true };
-      default:
-        return {
-          type: SchemaType.OBJECT,
-          nullable: true,
-        };
-    }
+  const zodType = getZodType(zodSchema);
+
+  switch (zodType) {
+    case 'ZodArray':
+      return {
+        type: SchemaType.ARRAY,
+        items: toGeminiSchema(zodSchema.element),
+      };
+    case 'ZodObject':
+      const properties: Record<string, any> = {};
+      const required: string[] = [];
+
+      Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
+        properties[key] = toGeminiSchema(value);
+        if (getZodType(value) !== 'ZodOptional') {
+          required.push(key);
+        }
+      });
+
+      return {
+        type: SchemaType.OBJECT,
+        properties,
+        required: required.length > 0 ? required : undefined,
+      };
+    case 'ZodString':
+      return {
+        type: SchemaType.STRING,
+        nullable: zodSchema.isOptional(),
+      };
+    case 'ZodNumber':
+      return {
+        type: SchemaType.NUMBER,
+        nullable: zodSchema.isOptional(),
+      };
+    case 'ZodBoolean':
+      return {
+        type: SchemaType.BOOLEAN,
+        nullable: zodSchema.isOptional(),
+      };
+    case 'ZodEnum':
+      return {
+        type: SchemaType.STRING,
+        enum: zodSchema._def.values,
+        nullable: zodSchema.isOptional(),
+      };
+    case 'ZodNullable':
+    case 'ZodOptional':
+      const innerSchema = toGeminiSchema(zodSchema._def.innerType);
+      return { ...innerSchema, nullable: true };
+    default:
+      return {
+        type: SchemaType.OBJECT,
+        nullable: true,
+      };
+  }
 }
-  
+
 export function toZodSchema(geminiSchema: any): any {
-    const z = require('zod'); // Dynamically import zod to avoid bundling it
-  
-    switch (geminiSchema.type) {
-      case SchemaType.ARRAY:
-        return z.array(toZodSchema(geminiSchema.items));
-  
-      case SchemaType.OBJECT:
-        const shape: Record<string, any> = {};
-        Object.entries(geminiSchema.properties).forEach(([key, value]: [string, any]) => {
+  const z = require('zod'); // Dynamically import zod to avoid bundling it
+
+  switch (geminiSchema.type) {
+    case SchemaType.ARRAY:
+      return z.array(toZodSchema(geminiSchema.items));
+
+    case SchemaType.OBJECT:
+      const shape: Record<string, any> = {};
+      Object.entries(geminiSchema.properties).forEach(
+        ([key, value]: [string, any]) => {
           let fieldSchema = toZodSchema(value);
           if (!geminiSchema.required || !geminiSchema.required.includes(key)) {
             fieldSchema = fieldSchema.optional();
           }
           shape[key] = fieldSchema;
-        });
-        return z.object(shape);
-  
-      case SchemaType.STRING:
-        return geminiSchema.nullable ? z.string().nullable() : z.string();
-  
-      case SchemaType.NUMBER:
-      case SchemaType.INTEGER:
-        return geminiSchema.nullable ? z.number().nullable() : z.number();
-  
-      case SchemaType.BOOLEAN:
-        return geminiSchema.nullable ? z.boolean().nullable() : z.boolean();
-  
-      default:
-        return geminiSchema.nullable ? z.any().nullable() : z.any();
-    }
-}  
+        },
+      );
+      return z.object(shape);
+
+    case SchemaType.STRING:
+      return geminiSchema.nullable ? z.string().nullable() : z.string();
+
+    case SchemaType.NUMBER:
+    case SchemaType.INTEGER:
+      return geminiSchema.nullable ? z.number().nullable() : z.number();
+
+    case SchemaType.BOOLEAN:
+      return geminiSchema.nullable ? z.boolean().nullable() : z.boolean();
+
+    default:
+      return geminiSchema.nullable ? z.any().nullable() : z.any();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,12 @@ export function toGeminiSchema(zodSchema: any): any {
         const properties: Record<string, any> = {};
         const required: string[] = [];
 
-        Object.entries(zodSchema.shape).forEach(
-          ([key, value]: [string, any]) => {
-            properties[key] = toGeminiSchema(value);
-            if (getZodType(value) !== 'ZodOptional') {
-              required.push(key);
-            }
-          },
-        );
+        Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
+          properties[key] = toGeminiSchema(value);
+          if (getZodType(value) !== 'ZodOptional') {
+            required.push(key);
+          }
+        });
 
         return {
           type: SchemaType.OBJECT,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { getZodType, SchemaType } from './util';
 
 export function toGeminiSchema(zodSchema: any): any {
     const zodType = getZodType(zodSchema);
-
+  
     switch (zodType) {
       case 'ZodArray':
         return {
@@ -13,12 +13,14 @@ export function toGeminiSchema(zodSchema: any): any {
         const properties: Record<string, any> = {};
         const required: string[] = [];
 
-        Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
-          properties[key] = toGeminiSchema(value);
-          if (getZodType(value) !== 'ZodOptional') {
-            required.push(key);
-          }
-        });
+        Object.entries(zodSchema.shape).forEach(
+          ([key, value]: [string, any]) => {
+            properties[key] = toGeminiSchema(value);
+            if (getZodType(value) !== 'ZodOptional') {
+              required.push(key);
+            }
+          },
+        );
 
         return {
           type: SchemaType.OBJECT,
@@ -57,38 +59,36 @@ export function toGeminiSchema(zodSchema: any): any {
         };
     }
 }
-
+  
 export function toZodSchema(geminiSchema: any): any {
     const z = require('zod'); // Dynamically import zod to avoid bundling it
-
+  
     switch (geminiSchema.type) {
       case SchemaType.ARRAY:
         return z.array(toZodSchema(geminiSchema.items));
-
+  
       case SchemaType.OBJECT:
         const shape: Record<string, any> = {};
-        Object.entries(geminiSchema.properties).forEach(
-          ([key, value]: [string, any]) => {
-            let fieldSchema = toZodSchema(value);
-            if (!geminiSchema.required || !geminiSchema.required.includes(key)) {
-              fieldSchema = fieldSchema.optional();
-            }
-            shape[key] = fieldSchema;
-          },
-        );
+        Object.entries(geminiSchema.properties).forEach(([key, value]: [string, any]) => {
+          let fieldSchema = toZodSchema(value);
+          if (!geminiSchema.required || !geminiSchema.required.includes(key)) {
+            fieldSchema = fieldSchema.optional();
+          }
+          shape[key] = fieldSchema;
+        });
         return z.object(shape);
-
+  
       case SchemaType.STRING:
         return geminiSchema.nullable ? z.string().nullable() : z.string();
-
+  
       case SchemaType.NUMBER:
       case SchemaType.INTEGER:
         return geminiSchema.nullable ? z.number().nullable() : z.number();
-
+  
       case SchemaType.BOOLEAN:
         return geminiSchema.nullable ? z.boolean().nullable() : z.boolean();
-
+  
       default:
         return geminiSchema.nullable ? z.any().nullable() : z.any();
     }
-}
+}  

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,92 +1,143 @@
 import { getZodType, SchemaType } from './util';
 
+function decorateGeminiSchema(geminiSchema: any, zodSchema: any) {
+  if (geminiSchema.nullable === undefined) {
+    geminiSchema.nullable = zodSchema.isOptional();
+  }
+
+  if (zodSchema.description) {
+    geminiSchema.description = zodSchema.description;
+  }
+
+  return geminiSchema;
+}
+
+function decorateZodSchema(z: any, geminiSchema: any) {
+  if (geminiSchema.nullable) {
+    z = z.nullable();
+  }
+  if (geminiSchema.description) {
+    z = z.describe(geminiSchema.description);
+  }
+
+  return z;
+}
+
 export function toGeminiSchema(zodSchema: any): any {
-    const zodType = getZodType(zodSchema);
-  
-    switch (zodType) {
-      case 'ZodArray':
-        return {
+  const zodType = getZodType(zodSchema);
+
+  switch (zodType) {
+    case 'ZodArray':
+      return decorateGeminiSchema(
+        {
           type: SchemaType.ARRAY,
           items: toGeminiSchema(zodSchema.element),
-        };
-      case 'ZodObject':
-        const properties: Record<string, any> = {};
-        const required: string[] = [];
+        },
+        zodSchema,
+      );
+    case 'ZodObject':
+      const properties: Record<string, any> = {};
+      const required: string[] = [];
 
-        Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
-          properties[key] = toGeminiSchema(value);
-          if (getZodType(value) !== 'ZodOptional') {
-            required.push(key);
-          }
-        });
+      Object.entries(zodSchema.shape).forEach(([key, value]: [string, any]) => {
+        properties[key] = toGeminiSchema(value);
+        if (getZodType(value) !== 'ZodOptional') {
+          required.push(key);
+        }
+      });
 
-        return {
+      return decorateGeminiSchema(
+        {
           type: SchemaType.OBJECT,
           properties,
           required: required.length > 0 ? required : undefined,
-        };
-      case 'ZodString':
-        return {
+        },
+        zodSchema,
+      );
+    case 'ZodString':
+      return decorateGeminiSchema(
+        {
           type: SchemaType.STRING,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodNumber':
-        return {
+        },
+        zodSchema,
+      );
+    case 'ZodNumber':
+      return decorateGeminiSchema(
+        {
           type: SchemaType.NUMBER,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodBoolean':
-        return {
+        },
+        zodSchema,
+      );
+    case 'ZodBoolean':
+      return decorateGeminiSchema(
+        {
           type: SchemaType.BOOLEAN,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodEnum':
-        return {
+        },
+        zodSchema,
+      );
+    case 'ZodEnum':
+      return decorateGeminiSchema(
+        {
           type: SchemaType.STRING,
           enum: zodSchema._def.values,
-          nullable: zodSchema.isOptional(),
-        };
-      case 'ZodNullable':
-      case 'ZodOptional':
-        const innerSchema = toGeminiSchema(zodSchema._def.innerType);
-        return { ...innerSchema, nullable: true };
-      default:
-        return {
+        },
+        zodSchema,
+      );
+    case 'ZodNullable':
+    case 'ZodOptional':
+      const innerSchema = toGeminiSchema(zodSchema._def.innerType);
+      return decorateGeminiSchema(
+        {
+          ...innerSchema,
+          nullable: true,
+        },
+        zodSchema,
+      );
+    default:
+      return decorateGeminiSchema(
+        {
           type: SchemaType.OBJECT,
           nullable: true,
-        };
-    }
+        },
+        zodSchema,
+      );
+  }
 }
-  
+
 export function toZodSchema(geminiSchema: any): any {
-    const z = require('zod'); // Dynamically import zod to avoid bundling it
-  
-    switch (geminiSchema.type) {
-      case SchemaType.ARRAY:
-        return z.array(toZodSchema(geminiSchema.items));
-  
-      case SchemaType.OBJECT:
-        const shape: Record<string, any> = {};
-        Object.entries(geminiSchema.properties).forEach(([key, value]: [string, any]) => {
+  const z = require('zod'); // Dynamically import zod to avoid bundling it
+
+  switch (geminiSchema.type) {
+    case SchemaType.ARRAY:
+      return decorateZodSchema(
+        z.array(toZodSchema(geminiSchema.items)),
+        geminiSchema,
+      );
+
+    case SchemaType.OBJECT:
+      const shape: Record<string, any> = {};
+      Object.entries(geminiSchema.properties).forEach(
+        ([key, value]: [string, any]) => {
           let fieldSchema = toZodSchema(value);
           if (!geminiSchema.required || !geminiSchema.required.includes(key)) {
             fieldSchema = fieldSchema.optional();
           }
           shape[key] = fieldSchema;
-        });
-        return z.object(shape);
-  
-      case SchemaType.STRING:
-        return geminiSchema.nullable ? z.string().nullable() : z.string();
-  
-      case SchemaType.NUMBER:
-      case SchemaType.INTEGER:
-        return geminiSchema.nullable ? z.number().nullable() : z.number();
-  
-      case SchemaType.BOOLEAN:
-        return geminiSchema.nullable ? z.boolean().nullable() : z.boolean();
-  
-      default:
-        return geminiSchema.nullable ? z.any().nullable() : z.any();
-    }
-}  
+        },
+      );
+      return decorateZodSchema(z.object(shape), geminiSchema);
+
+    case SchemaType.STRING:
+      return decorateZodSchema(z.string(), geminiSchema);
+
+    case SchemaType.NUMBER:
+    case SchemaType.INTEGER:
+      return decorateZodSchema(z.number(), geminiSchema);
+
+    case SchemaType.BOOLEAN:
+      return decorateZodSchema(z.boolean(), geminiSchema);
+
+    default:
+      return decorateZodSchema(z.any(), geminiSchema);
+  }
+}


### PR DESCRIPTION
Using `.nullable()` in a non-object property in the Zodiac schema results in the default switch case, which assumes the property is an object. Really, this should produce the same gemini schema as `.optional()`, but keep the field as required.